### PR TITLE
fix: Add local_name is not None check

### DIFF
--- a/src/led_ble/led_ble.py
+++ b/src/led_ble/led_ble.py
@@ -429,6 +429,7 @@ class LEDBLE:
         """Return if the device is a dream."""
         return self.model_num in (0x10,) or (
             self._advertisement_data is not None
+            and self._advertisement_data.local_name is not None
             and self._advertisement_data.local_name.startswith("Dream")
         )
 


### PR DESCRIPTION
AdvertisementData.local_name is an Optional[str] field, so make sure to check presence before computing on the value.

See #92.

Patch locally applied to install, working as before.