### PR TITLE
fix: convert preset pattern result to bytes for mypy 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ exclude_lines = [
 profile = "black"
 known_first_party = ["led_ble", "tests"]
 
+[tool.ruff]
+target-version = "py39"
+
 [tool.mypy]
 check_untyped_defs = true
 disallow_any_generics = true

--- a/src/led_ble/led_ble.py
+++ b/src/led_ble/led_ble.py
@@ -272,18 +272,20 @@ class LEDBLE:
 
     def _generate_preset_pattern(
         self, pattern: int, speed: int, brightness: int
-    ) -> bytearray:
+    ) -> bytes:
         """Generate the preset pattern protocol bytes."""
         if self.dream:
             # TODO: move this to the protocol
             brightness = int(brightness * 255 / 100)
             speed = int(speed * 255 / 100)
-            return bytearray([0x9E, 0x00, pattern, speed, brightness, 0x00, 0xE9])
+            return bytes([0x9E, 0x00, pattern, speed, brightness, 0x00, 0xE9])
         PresetPattern.valid_or_raise(pattern)
         if not (1 <= brightness <= 100):
             raise ValueError("Brightness must be between 1 and 100")
         assert self._protocol is not None  # nosec
-        return self._protocol.construct_preset_pattern(pattern, speed, brightness)
+        return bytes(
+            self._protocol.construct_preset_pattern(pattern, speed, brightness)
+        )
 
     async def async_set_preset_pattern(
         self, effect: int, speed: int, brightness: int = 100


### PR DESCRIPTION
The pre-commit autoupdate in #122 bumped mypy to v2.x, which is stricter and rejects passing a bytearray where bytes is expected; this broke CI on main.

Two small changes:

- `_generate_preset_pattern` now returns `bytes`, wrapping both the dream literal and the `flux_led` `construct_preset_pattern` result (which returns a bytearray) so the downstream `_send_command(list[bytes] | bytes)` signature is satisfied.
- Adds an empty `[tool.ruff]` section pinning `target-version = "py39"`, so ruff anchors at the project root and matches the supported Python range declared in `[project]` and `[tool.poetry.dependencies]`.

Tests still pass locally (93 passed).