### PR TITLE
fix: authenticate with default password on connect for QHM-* controllers

### DIFF
--- a/src/led_ble/led_ble.py
+++ b/src/led_ble/led_ble.py
@@ -51,6 +51,11 @@ DEFAULT_ATTEMPTS = 3
 DREAM_EFFECTS = {f"Effect {i + 1}": i for i in range(0, 255)}
 DREAM_EFFECT_LIST = list(DREAM_EFFECTS)
 
+# Factory-default password handshake ("1234"). Some controllers (e.g. QHM-*)
+# silently ignore control commands such as power on/off until it is sent, so it
+# is issued once per connection. It is a no-op on devices that do not require it.
+LED_PASSWORD = bytes((0xCF, 0x01, 0x02, 0x03, 0x04, 0xFC))
+
 
 class LEDBLE:
     def __init__(
@@ -381,6 +386,7 @@ class LEDBLE:
                 "%s: Subscribe to notifications; RSSI: %s", self.name, self.rssi
             )
             await client.start_notify(self._read_char, self._notification_handler)
+            await self._authenticate()
             if not self._protocol:
                 await self._resolve_protocol()
 
@@ -649,6 +655,10 @@ class LEDBLE:
                 self._write_char = char
                 break
         return bool(self._read_char and self._write_char)
+
+    async def _authenticate(self) -> None:
+        """Authenticate the session so the device accepts control commands."""
+        await self._send_command_while_connected([LED_PASSWORD])
 
     async def _resolve_protocol(self) -> None:
         """Resolve protocol."""

--- a/tests/test_led_ble_connection.py
+++ b/tests/test_led_ble_connection.py
@@ -15,7 +15,7 @@ from bleak_retry_connector import BleakNotFoundError
 
 from led_ble.const import STATE_COMMAND
 from led_ble.exceptions import CharacteristicMissingError
-from led_ble.led_ble import LEDBLE
+from led_ble.led_ble import LED_PASSWORD, LEDBLE
 
 # A model_num / version that resolves to a real flux_led protocol class.
 KNOWN_MODEL = 0xE3
@@ -236,12 +236,14 @@ def test_ensure_connected_happy_path(loop, led, monkeypatch):
     )
     led._resolve_characteristics = Mock(return_value=True)
     led._resolve_protocol = AsyncMock()
+    led._send_command_while_connected = AsyncMock()
     led._protocol = None
 
     loop.run_until_complete(led._ensure_connected())
     try:
         assert led._client is client
         client.start_notify.assert_awaited_once()
+        led._send_command_while_connected.assert_awaited_once_with([LED_PASSWORD])
         led._resolve_protocol.assert_awaited_once()
     finally:
         if led._disconnect_timer:
@@ -414,6 +416,7 @@ def test_ensure_connected_skips_protocol_resolve_when_already_set(
     )
     led._resolve_characteristics = Mock(return_value=True)
     led._resolve_protocol = AsyncMock()
+    led._authenticate = AsyncMock()
     led._protocol = Mock()  # already resolved from a prior connection
 
     loop.run_until_complete(led._ensure_connected())


### PR DESCRIPTION
I found that my QHM-S564 controller for a light strip wouldn't turn on via Home Assistant but would via the Happy Lighting app. The app sends a password upon connection, in addition to the power on command this library already uses. Tested this fix in my local Home Assistant install and it appears to make power on work reliably.

This PR implements that password sending on connection. I don't believe this should cause any adverse effects for controllers that don't need passwords, but worth verifying.