### PR TITLE
docs: clarify project scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ Contributions are welcome, and they are greatly appreciated! Every little helps,
 
 You can contribute in many ways:
 
+## Project Scope
+
+This library supports unbranded Bluetooth LE LED devices that share the
+same family of protocols. Contributions that add model numbers or fix
+protocol handling for these similar-protocol devices are very welcome.
+
+Support for brand-specific ecosystems such as Govee is out of scope. These
+brands use their own protocols and cover hundreds of models with complex
+options, which is more than this library can absorb; they deserve a
+dedicated library. Pull requests adding brand-specific protocol stacks
+will be closed with a suggestion to publish a standalone library instead.
+
 ## Types of Contributions
 
 ### Report Bugs

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@
 
 Control a wide range of LED BLE devices
 
+## What this library is
+
+This library controls generic, unbranded Bluetooth LE LED controllers and
+bulbs that share the same family of protocols. These devices are sold under
+many names and typically advertise names such as `Triones:`, `LEDBLE-`,
+`LEDBlue-`, `QHM-`, and `Dream~`.
+
+## What this library is not
+
+This library is not a universal driver for every Bluetooth LE light.
+Brand-specific ecosystems such as Govee use their own protocols and span
+hundreds of models with complex, per-model options. Supporting them here
+would mean maintaining what is effectively a separate driver inside this
+one, so they should live in their own dedicated libraries. The same applies
+to devices that speak an entirely different protocol, such as yeelight-bt
+or ALLOYSEED lights.
+
 ## Installation
 
 Install this via pip (or your favourite package manager):


### PR DESCRIPTION
This library is for unbranded BLE LED devices that share the same protocol family, but nothing in the docs says so. This adds a scope section to the README and CONTRIBUTING so contributors know brand specific ecosystems like Govee need their own library, since that means supporting hundreds of models with complex options. Refs #40, #151.